### PR TITLE
Add basic MEXC spot trading bot with Telegram notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# Spot
+# MEXC Spot Trading Bot
+
+This repository provides a simple Python script that can place a spot limit order on MEXC and forward the exchange response to a Telegram chat.
+
+## Usage
+
+1. Export the required environment variables:
+   - `MEXC_API_KEY`
+   - `MEXC_API_SECRET`
+   - `TELEGRAM_TOKEN`
+   - `TELEGRAM_CHAT_ID`
+2. Run the script:
+
+```bash
+python mexc_bot.py
+```
+
+When all variables are provided, the bot submits a BTCUSDT limit order and sends the JSON response to the configured Telegram chat. Without credentials the script prints a helpful message and exits.

--- a/mexc_bot.py
+++ b/mexc_bot.py
@@ -1,0 +1,54 @@
+import os
+import time
+import hmac
+import hashlib
+import requests
+
+API_KEY = os.getenv("MEXC_API_KEY")
+API_SECRET = os.getenv("MEXC_API_SECRET")
+TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
+TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID")
+
+BASE_URL = "https://api.mexc.com"
+
+
+def sign(payload: str) -> str:
+    """Return HMAC SHA256 signature."""
+    if API_SECRET is None:
+        raise ValueError("MEXC_API_SECRET not set")
+    return hmac.new(API_SECRET.encode(), payload.encode(), hashlib.sha256).hexdigest()
+
+
+def place_order(symbol: str, side: str, type_: str, quantity: str, price: str) -> requests.Response:
+    """Place a spot order on MEXC."""
+    timestamp = int(time.time() * 1000)
+    payload = f"symbol={symbol}&side={side}&type={type_}&quantity={quantity}&price={price}&timestamp={timestamp}"
+    signature = sign(payload)
+    headers = {"X-MEXC-APIKEY": API_KEY}
+    url = f"{BASE_URL}/api/v3/order"
+    return requests.post(url, headers=headers, data=f"{payload}&signature={signature}")
+
+
+def send_telegram(message: str) -> None:
+    """Send a message via Telegram bot."""
+    if not TELEGRAM_TOKEN or not TELEGRAM_CHAT_ID:
+        print("Telegram credentials missing. Skipping message send.")
+        return
+    url = f"https://api.telegram.org/bot{TELEGRAM_TOKEN}/sendMessage"
+    requests.post(url, data={"chat_id": TELEGRAM_CHAT_ID, "text": message})
+
+
+def main() -> None:
+    required = [API_KEY, API_SECRET, TELEGRAM_TOKEN, TELEGRAM_CHAT_ID]
+    if not all(required):
+        print("Environment variables missing. Set MEXC_API_KEY, MEXC_API_SECRET, TELEGRAM_TOKEN and TELEGRAM_CHAT_ID.")
+        return
+    try:
+        response = place_order("BTCUSDT", "BUY", "LIMIT", "0.001", "20000")
+        send_telegram(f"Order response: {response.json()}")
+    except Exception as exc:
+        print(f"Error placing order or sending message: {exc}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `mexc_bot.py` to place a spot limit order on MEXC and send the response to Telegram
- document environment variables and usage in `README.md`

## Testing
- `python -m py_compile mexc_bot.py`
- `python mexc_bot.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not find a version that satisfies the requirement requests: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a42bc482708327b8cac1c4ceddaabb